### PR TITLE
Deprecate auth endpoint

### DIFF
--- a/api/core/api_token_migration_test.py
+++ b/api/core/api_token_migration_test.py
@@ -1,5 +1,3 @@
-import requests
-
 from tests import config
 
 from tests.api.utils import *

--- a/api/core/api_token_migration_test.py
+++ b/api/core/api_token_migration_test.py
@@ -11,14 +11,14 @@ def test_001_simple_api_token_test(pretty_print, mist_core,
     mist_api_token_string = "mist_1 " + config.EMAIL + \
                             ":" + user_with_api_token.mist_api_token
     print "\n>>>  Pinging core with old api token"
-    response = mist_core.ping(mist_api_token_string).post()
+    response = mist_core.check_token(mist_api_token_string).post()
     assert_response_ok(response)
     token = ApiToken.objects.get(token=user_with_api_token.mist_api_token)
     assert_equal(token.get_user().get_id(),
                  user_with_api_token.get_id(),
                  'ApiToken user is different than the actual user')
-    response = mist_core.ping(mist_api_token_string).post()
-    assert response.status_code == requests.codes.ok
+    response = mist_core.check_token(mist_api_token_string).post()
+    assert_response_ok(response)
     print "Success!!!!"
 
 
@@ -28,7 +28,7 @@ def test_002_short_api_token_test(pretty_print, mist_core,
     mist_api_token_string = "mist_1 " + config.EMAIL + \
                             ":" + user_with_short_api_token.mist_api_token
     print "\n>>>  Pinging core with short old api token"
-    response = mist_core.ping(mist_api_token_string).post()
+    response = mist_core.check_token(mist_api_token_string).post()
     assert_response_ok(response)
     short_token = '0' + user_with_short_api_token.mist_api_token
     token = ApiToken.objects.get(token=short_token)

--- a/api/core/api_token_test.py
+++ b/api/core/api_token_test.py
@@ -7,6 +7,8 @@ from time import sleep
 
 from tests.api.utils import *
 
+from tests.api.helpers import get_random_str
+
 
 def test_001_get_api_token_with_empty_fields(pretty_print, mist_core):
     print "\n>>>  POSTing /auth to get a token with empty creds:"
@@ -52,8 +54,8 @@ def test_004_get_api_token(pretty_print, cache, mist_core, email, password1):
 
 
 def test_005_confirm_api_token(pretty_print, cache, mist_core, email):
-    print "\n>>>  POSTing /ping again to see if my token is recognized:"
-    response = mist_core.ping(api_token=cache.get('api_token_test/api_token',
+    print "\n>>>  POSTing /check_token again to see if my token is recognized:"
+    response = mist_core.check_token(api_token=cache.get('api_token_test/api_token',
                                                   '')).post()
     assert_response_ok(response)
     assert_equal(email, response.json().get('hello', None), response.content)
@@ -104,8 +106,8 @@ def test_008_create_short_lived_api_token(pretty_print, cache, mist_core, email,
     assert_is_not_none(response.json().get('token', None))
     assert_is_not_none(response.json().get('id', None))
     assert_is_not_none(response.json().get('name', None))
-    print "\n>>>  POSTing /ping to see that new token works fine"
-    response = mist_core.ping(api_token=api_token).post()
+    print "\n>>>  POSTing /check_token to see that new token works fine"
+    response = mist_core.check_token(api_token=api_token).post()
     assert_response_ok(response)
     assert_equal(email, response.json().get('hello'))
     print "\n>>>  Sleeping for 10 secs"
@@ -113,8 +115,8 @@ def test_008_create_short_lived_api_token(pretty_print, cache, mist_core, email,
         sleep(1)
         sys.stdout.write('.')
         sys.stdout.flush()
-    print "\n>>>  POSTing /ping to see that new token is invalid"
-    response = mist_core.ping(api_token=api_token).post()
+    print "\n>>>  POSTing /check_token to see that new token is invalid"
+    response = mist_core.check_token(api_token=api_token).post()
     assert_response_unauthorized(response)
     print "\n>>>  DELETEing /tokens for second ApiToken i got"
     response = mist_core.revoke_token(
@@ -208,19 +210,6 @@ def test_014_revoke_api_token(pretty_print, cache, mist_core):
         api_token=cache.get('api_token_test/api_token', ''),
         api_token_id=cache.get('api_token_test/api_token_id', '')).delete()
     assert_response_ok(response)
-    print "Success!!!!"
-
-
-def test_015_fail_create_token_with_revoked_api_token(pretty_print,
-                                                      cache, mist_core, email,
-                                                      password1):
-    print "\n>>>  POSTing /tokens to make sure that token has been revoked"
-    response = mist_core.create_token(email=email,
-                                      password=password1,
-                                      api_token=cache.get(
-                                          'api_token_test/api_token', ''),
-                                      new_api_token_name='bla', ttl=0).post()
-    assert_response_unauthorized(response)
     print "Success!!!!"
 
 

--- a/api/core/core.py
+++ b/api/core/core.py
@@ -44,8 +44,8 @@ class MistCoreApi(MistIoApi):
         req.put = req.unavailable_api_call
         return req
 
-    def create_token(self, email, password, api_token, ttl=None, org_id=None,
-                     new_api_token_name=None):
+    def create_token(self, email, password, api_token=None, ttl=None,
+                     org_id=None, new_api_token_name=None):
         data = {
             'email': email,
             'password': password,
@@ -76,8 +76,8 @@ class MistCoreApi(MistIoApi):
         req.put = req.unavailable_api_call
         return req
 
-    def ping(self, api_token):
-        req = MistRequests(uri=self.uri + '/ping', api_token=api_token)
+    def check_token(self, api_token):
+        req = MistRequests(uri=self.uri + '/check_token', api_token=api_token)
         req.put = req.unavailable_api_call
         req.delete = req.unavailable_api_call
         return req

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -75,12 +75,14 @@ def add_bash_script(mist_core, valid_api_token):
 def get_teams_with_name(name, teams):
     return filter(lambda x: x['name'] == name, teams)
 
+def get_random_str():
+    return ''.join([random.choice(string.ascii_letters + string.digits) for _ in
+                    range(6)])
+
 
 def get_random_team_name(existing_teams):
     while True:
-        random_team_name = ''.join([random.choice(string.ascii_letters +
-                                                    string.digits) for _ in
-                                      range(6)])
+        random_team_name = get_random_str()
         teams = get_teams_with_name(random_team_name, existing_teams)
         if len(teams) == 0:
             return random_team_name
@@ -92,9 +94,7 @@ def get_keys_with_name(name, keys):
 
 def get_random_key_name(existing_keys):
      while True:
-        random_key_name = ''.join([random.choice(string.ascii_letters +
-                                                string.digits) for _ in
-                                  range(6)])
+        random_key_name = get_random_str()
         keys = get_keys_with_name(random_key_name, existing_keys)
         if len(keys) == 0:
             return random_key_name

--- a/gui/core/pr/features/user_actions.feature
+++ b/gui/core/pr/features/user_actions.feature
@@ -26,34 +26,35 @@ Feature: Login Scenarios
     And I revoke the api token with name blabla
     Then I test the api token "BLABLA_TOKEN". It should fail.
     And I logout
+    And I wait for 2 seconds
 
-#  @check-error-messages
-#  Scenario: Make sure that the error messages appear
-#    When I visit mist.core
-#
-#    When I open the login popup
-#    Then I click the email button in the landing page popup
-#    And I enter my alt credentials for login
-#    And I click the sign in button in the landing page popup
-#    Then I wait for some reaction for max 3 seconds
-#    Then there should be a message saying "Authentication failed!" for error in "authentication"
-#    Then I close the "Login" popup
-#    And I wait for 1 seconds
-#
-#    When I open the login popup
-#    Then I click the email button in the landing page popup
-#    And I enter my invalid_email credentials for login
-#    And I click the sign in button in the landing page popup
-#    Then I wait for some reaction for max 3 seconds
-#    Then there should be a message saying "Please enter a valid email" for error in "email"
-#    Then I close the "Login" popup
-#    And I wait for 1 seconds
-#
-#    When I open the login popup
-#    Then I click the email button in the landing page popup
-#    And I enter my invalid_no_password credentials for login
-#    And I click the sign in button in the landing page popup
-#    Then I wait for some reaction for max 3 seconds
-#    Then there should be a message saying "Please enter your password" for error in "password"
-#    Then I close the "Login" popup
-#    And I wait for 1 seconds
+  @check-error-messages
+  Scenario: Make sure that the error messages appear
+    When I visit mist.core
+
+    When I open the login popup
+    Then I click the email button in the landing page popup
+    And I enter my alt credentials for login
+    And I click the sign in button in the landing page popup
+    Then I wait for some reaction for max 3 seconds
+    Then there should be a message saying "Authentication failed!" for error in "authentication"
+    Then I close the "Login" popup
+    And I wait for 1 seconds
+
+    When I open the login popup
+    Then I click the email button in the landing page popup
+    And I enter my invalid_email credentials for login
+    And I click the sign in button in the landing page popup
+    Then I wait for some reaction for max 3 seconds
+    Then there should be a message saying "Please enter a valid email" for error in "email"
+    Then I close the "Login" popup
+    And I wait for 1 seconds
+
+    When I open the login popup
+    Then I click the email button in the landing page popup
+    And I enter my invalid_no_password credentials for login
+    And I click the sign in button in the landing page popup
+    Then I wait for some reaction for max 3 seconds
+    Then there should be a message saying "Please enter your password" for error in "password"
+    Then I close the "Login" popup
+    And I wait for 1 seconds

--- a/gui/steps/api_tokens.py
+++ b/gui/steps/api_tokens.py
@@ -46,9 +46,10 @@ def get_new_token_value(context, token_name):
 
 @step(u'I test the api token "{token_value}". It should {work_or_fail}.')
 def test_api_token(context, token_value, work_or_fail):
+    from tests.api.core.core import MistCoreApi as mist_core
     if work_or_fail not in ['work', 'fail']:
         raise ValueError('Token can either work or fail.')
-    response = mist_core(context.mist_config['MIST_URL']).ping(api_token=context.mist_config[token_value]).post()
+    response = mist_core(context.mist_config['MIST_URL']).check_token(api_token=context.mist_config[token_value]).post()
     if work_or_fail == 'work':
         assert response.status_code == 200, "Api token with value %s did not " \
                                             "work" % context.mist_config[token_value]


### PR DESCRIPTION
Tests for [deprecate_auth_endpoint](https://github.com/mistio/mist.core/pull/1730) branch of mist.core